### PR TITLE
feat(repo): Adding pre-commit hook for `clang-format`

### DIFF
--- a/scripts/config-repo.sh
+++ b/scripts/config-repo.sh
@@ -2,4 +2,6 @@
 
 # run this script from inside the folder:
 # cd scripts
-git config commit.template $PWD/../.gitmessage
+# git config commit.template $PWD/../.gitmessage
+cp pre-commit $PWD/../.git/hooks/pre-commit
+chmod +x $PWD/../.git/hooks/pre-commit

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+exec docker compose run --rm -w /workspace -v "$ROOT:/workspace" design-patterns /workspace/scripts/pre-commit-container.sh

--- a/scripts/pre-commit-container.sh
+++ b/scripts/pre-commit-container.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+cd "$(git rev-parse --show-toplevel)"
+
+# Staged C/C++ files under src/
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^src/.*\.(cpp|c|h)$' || true)
+if [ -z "$FILES" ]; then
+  exit 0
+fi
+
+echo "Running clang-format (dry-run) on staged files..."
+if ! echo "$FILES" | xargs clang-format --dry-run -Werror 2>/dev/null; then
+  echo ""
+  echo "Commit blocked: some staged files need formatting. Run the fix target, then git add and commit again."
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
feat(repo): Adding pre-commit hook for `clang-format`

This PR adds a git pre-commit hook to run the `clang-format` on the modified files.
If the execution returns success, it goes on with the commit. If not, it doesn't let you
create the commit.

This must be installed running `./scripts/config-repo.sh`. The clang-format process run
inside the container, so it must be up already (running `docker compose up -d`)

Signed-off-by: Federico Roux <rouxfederico@gmail.com>